### PR TITLE
[GH-272] restore explicit resource names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - resolved cookstyle error: libraries/user.rb:168:17 convention: `Layout/IndentationConsistency`
 - resolved cookstyle error: libraries/user.rb:169:15 convention: `Layout/IndentationConsistency`
 - resolved cookstyle error: libraries/user.rb:169:17 convention: `Layout/IndentationConsistency`
+- resolved regression in custom resource names (#272)
 - Resolve cookstyle issues
 - Comment out ChefSpec until defintions are converted to custom resources
 - Disable platforms that do not currently work

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- resolved regression in custom resource names (#272)
+
 ## 4.1.2 - *2021-08-30*
 
 - Standardise files with files in sous-chefs/repo-management
@@ -22,7 +24,6 @@
 - resolved cookstyle error: libraries/user.rb:168:17 convention: `Layout/IndentationConsistency`
 - resolved cookstyle error: libraries/user.rb:169:15 convention: `Layout/IndentationConsistency`
 - resolved cookstyle error: libraries/user.rb:169:17 convention: `Layout/IndentationConsistency`
-- resolved regression in custom resource names (#272)
 - Resolve cookstyle issues
 - Comment out ChefSpec until defintions are converted to custom resources
 - Disable platforms that do not currently work

--- a/resources/agent.rb
+++ b/resources/agent.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+provides :mongodb_agent
+
 property :type, String, name_property: true, equal_to: %w(automation backup monitoring)
 property :config, Hash
 property :group, String

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -1,3 +1,5 @@
+provides :mongodb_user
+
 property :username, String, name_property: true
 property :password, String
 property :roles, Array


### PR DESCRIPTION
## Description

These explicit resource names were removed in https://github.com/sous-chefs/mongodb/pull/262

The default name of a chef resource, however, is to concatenate
the cookbook name with the resource file name. This cookbook
sets the cookbook name as 'sc-mongodb' which results in a
resource name like 'sc_mongodb_user' or 'sc_mongodb_agent'

These explicit 'provides' calls should allow the cookbook recipes
which use these resources to find them again on Chef 14

### Issues Resolved

- #272 

### Check List
- [x] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [x] ~~New functionality includes testing~~ this change fixes a regression
- [x] ~~New functionality has been documented in the README if applicable~~ this change fixes a regression

Signed-off-by: David Alpert <david@spinthemoose.com>
